### PR TITLE
Add allsky_keolapse module — keogram ring timelapse (v0.9.1)

### DIFF
--- a/allsky_keolapse/README.md
+++ b/allsky_keolapse/README.md
@@ -21,8 +21,12 @@ ring around each frame, and encodes the result with ffmpeg to
   `timelapseheight`, `timelapsefps`, `timelapsebitrate`, `timelapsevcodec`,
   `timelapsepixfmt` and `timelapsefflog` settings are used.
 - Uploads use the standard `scripts/upload.sh` and honor `uselocalwebsite`,
-  `useremotewebsite` and `useremotewebserver`, placing the video in the
-  website's `videos` directory.
+  `useremotewebsite` and `useremoteserver`. The video is uploaded with its
+  dated filename (`keolapse-YYYYMMDD.mp4`) into a dedicated subdirectory
+  (default `keolapses`, configurable) so it never overwrites the regular
+  timelapse video. For remote (sftp/scp/ftp) destinations this subdirectory
+  must already exist on the server; the local-website subdirectory is created
+  automatically.
 
 ## Events
 

--- a/allsky_keolapse/allsky_keolapse.py
+++ b/allsky_keolapse/allsky_keolapse.py
@@ -281,7 +281,7 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 		"name": "Keolapse Generator",
 		"description": "Creates a timelapse video with the keogram wrapped as a ring around the sky image",
 		"module": "allsky_keolapse",
-		"version": "v0.9.0",
+		"version": "v0.9.1",
 		"pythonversion": "3.10.0",
 		"centersettings": "false",
 		"testable": "true",
@@ -335,6 +335,7 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 			"framerate": "12",
 			"max_length": "120",
 			"upload": "false",
+			"upload_subdir": "keolapses",
 			"circle_radius_factor": "0.47",
 			"center_x_offset": "0",
 			"center_y_offset": "0",
@@ -414,11 +415,17 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 			"upload": {
 				"required": "false",
 				"description": "Upload",
-				"help": "Enable to upload the keolapse video to an Allsky Website and/or remote server (into the <code>videos</code> directory).<br><i>Note: Website(s) or remote server must be configured in Allsky Settings.</i>",
+				"help": "Enable to upload the keolapse video to a local/remote Allsky Website and/or remote server, into the subdirectory named below.<br><i>Note: Website(s) or remote server must be configured in Allsky Settings. For remote uploads the subdirectory must already exist on the server.</i>",
 				"tab": "Video",
 				"type": {
 					"fieldtype": "checkbox"
 				}
+			},
+			"upload_subdir": {
+				"required": "false",
+				"description": "Upload Subdirectory",
+				"help": "Subdirectory under the website/server image directory to upload keolapse videos into (e.g. <code>keolapses</code>). Keeps keolapse videos separate from the regular timelapse <code>videos</code> directory. The uploaded file keeps its dated name (keolapse-YYYYMMDD.mp4). For remote (sftp/scp/ftp) uploads this directory must already exist on the server.",
+				"tab": "Video"
 			},
 			"circle_radius_factor": {
 				"required": "true",
@@ -631,10 +638,22 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 		},
 		"businfo": [],
 		"changelog": {
+			"v0.9.1": [
+				{
+					"author": "Andy Felong",
+					"authorurl": "https://github.com/AndyOfLinux",
+					"changes": [
+						"Fixed upload overwriting the regular timelapse video: keolapse now uploads into its own subdirectory (default 'keolapses') with its dated filename instead of the videos directory / timelapse destination name",
+						"Added 'Upload Subdirectory' setting (default 'keolapses')",
+						"Corrected remote-server setting name (useremoteserver)",
+						"Local website upload subdirectory is created automatically; clearer error when a remote subdirectory is missing"
+					]
+				}
+			],
 			"v0.9.0": [
 				{
 					"author": "Andy Felong",
-					"authorurl": "https://martzobservatory.org",
+					"authorurl": "https://github.com/AndyOfLinux",
 					"changes": [
 						"Refactored to Allsky v2025 module architecture (ALLSKYMODULEBASE class)",
 						"Core timelapse settings now read via allsky_shared.getSetting() instead of parsing settings.json",
@@ -710,6 +729,7 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 		self.max_length = self.get_param('max_length', 120, int)
 		self.resolution = self.get_param('resolution', '720p', str, True)
 		self.upload = self._get_bool('upload', False)
+		self.upload_subdir = (self.get_param('upload_subdir', 'keolapses', str) or 'keolapses').strip().strip('/')
 
 		# Image / ring settings
 		self.circle_radius_factor = self.get_param('circle_radius_factor', 0.47, float)
@@ -1362,31 +1382,59 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 		except Exception as e:
 			return 1, '', str(e)
 
+	@staticmethod
+	def _join_remote_dir(base, subdir):
+		'''Join a remote image dir and subdir into a clean absolute-style path.
+
+		upload.sh uses the directory argument verbatim as the destination
+		(e.g. "cd '<dir>'" for sftp), so we just normalise slashes and append
+		the keolapse subdirectory. We deliberately do not use os.path.join,
+		since the remote server may use a different path separator convention
+		than the Pi.
+		'''
+		base = (base or '').rstrip('/')
+		subdir = (subdir or '').strip('/')
+		if not base:
+			return subdir
+		return f'{base}/{subdir}' if subdir else base
+
 	def _upload_video(self, video_path, file_name):
-		'''Upload the video to configured Allsky Websites / remote server via upload.sh.'''
+		'''Upload the keolapse video via Allsky's standard upload.sh.
+
+		The video is uploaded with its dated filename (keolapse-YYYYMMDD.mp4)
+		into a dedicated subdirectory (default "keolapses") of each enabled
+		destination, so it never collides with the regular timelapse video.
+
+		Note: for remote sftp/scp/ftp uploads, upload.sh does NOT create the
+		destination directory - it must already exist on the server. The
+		local-website directory is created here automatically.
+		'''
 		upload_script = os.path.join(self._allsky_home, 'scripts', 'upload.sh')
+		subdir = self.upload_subdir
 		messages = []
 
 		targets = []
+
+		# Local Allsky Website (on the Pi) - we can create the directory.
 		if self._setting_bool('uselocalwebsite'):
-			targets.append((
-				'--local-web',
-				os.path.join(self._allsky_home, 'html', 'allsky', 'videos'),
-				file_name
-			))
+			local_dir = os.path.join(self._allsky_home, 'html', 'allsky', subdir)
+			try:
+				os.makedirs(local_dir, exist_ok=True)
+			except Exception as e:
+				self.klog(0, f'ERROR: could not create local website dir {local_dir}: {e}')
+			targets.append(('--local-web', local_dir, file_name))
+
+		# Remote Allsky Website (sftp/scp/ftp/etc via upload.sh).
 		if self._setting_bool('useremotewebsite'):
-			targets.append((
-				'--remote-web',
-				self._setting_str('remotewebsiteimagedir', '') + '/videos',
-				file_name
-			))
-		if self._setting_bool('useremotewebserver'):
-			dest_name = self._setting_str('remoteservervideodestinationname', '') or file_name
-			targets.append((
-				'--remote-server',
-				self._setting_str('remoteserverimagedir', '') + '/videos',
-				dest_name
-			))
+			remote_dir = self._join_remote_dir(
+				self._setting_str('remotewebsiteimagedir', ''), subdir)
+			targets.append(('--remote-web', remote_dir, file_name))
+
+		# Remote server (note: the core setting is "useremoteserver").
+		if self._setting_bool('useremoteserver') or self._setting_bool('useremotewebserver'):
+			remote_dir = self._join_remote_dir(
+				self._setting_str('remoteserverimagedir', ''), subdir)
+			targets.append(('--remote-server', remote_dir, file_name))
 
 		if not targets:
 			self.klog(1, 'Upload requested but no Allsky Website or remote server is enabled in Allsky Settings')
@@ -1399,7 +1447,15 @@ class ALLSKYKEOLAPSE(ALLSKYMODULEBASE):
 				self.klog(1, f'Keolapse uploaded successfully via {target} to {remote_dir}/{target_file}')
 				messages.append(f'{target} ok')
 			else:
-				self.klog(0, f'ERROR: Failed to upload keolapse via {target} (rc={rc}). STDERR:\n{err}')
+				err_text = (err or '').strip()
+				# sftp/scp fail this way when the subdir is missing on the server.
+				if 'cd' in err_text.lower() or 'no such file' in err_text.lower():
+					self.klog(0,
+						f"ERROR: Upload via {target} failed (rc={rc}). The '{subdir}' "
+						f"directory may not exist on the destination: {remote_dir}. "
+						f"Create it once on the server, then retry. STDERR:\n{err_text}")
+				else:
+					self.klog(0, f'ERROR: Failed to upload keolapse via {target} (rc={rc}). STDERR:\n{err_text}')
 				messages.append(f'{target} failed')
 
 		return ', '.join(messages)

--- a/allsky_keolapse/manifest.json
+++ b/allsky_keolapse/manifest.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "module": "allsky_keolapse",
-  "generated_utc": "2026-06-10T16:24:25Z",
+  "generated_utc": "2026-06-13T15:06:48Z",
   "hash_algorithm": "sha256",
   "files": {
     "README.md": {
-      "sha256": "727b8738d4ea085e103b0d010105db0f45fa2ff51ea2a36b8b58e12879c993c7",
-      "size": 1924,
+      "sha256": "cb86e7454bbeae0051d8e3c7b8e851dc02bb8e2be003667310f3d8f2f7b999db",
+      "size": 2212,
       "mode": "644"
     },
     "allsky_keolapse.py": {
-      "sha256": "33167aff9a5a6a645acc6759b3f730fdf25e4af7b939cdb289fec07ecfeb55a4",
-      "size": 48952,
+      "sha256": "421f0a24eb2d05408e79d3f1ef271b3f890bea0275d2f0849d6018e3a71335d4",
+      "size": 52068,
       "mode": "644"
     }
   },


### PR DESCRIPTION
Fixes upload overwriting the timelapse video; uploads to keolapses/ subdir with dated filename.## allsky_keolapse v0.9.1

Keogram-ring timelapse module for Allsky, built on the v2025 module
architecture (ALLSKYMODULEBASE). Generates a timelapse video with the night's
keogram wrapped as a ring around the circular sky image, with a progress sweep
indicating position in the night. Inspired by indi-allsky's keogram timelapse.

Addresses #277.

### Settings pulled from core Allsky
- Image extension derived from the core `filename` setting.
- "Use Timelapse Settings" reuses the core timelapse width/height/fps/bitrate/vcodec/pixfmt/fflog settings.
- Uploads use the standard `scripts/upload.sh` and honor `uselocalwebsite`, `useremotewebsite`, and `useremoteserver`.

### Upload behavior
- Uploads the dated file `keolapse-YYYYMMDD.mp4` into a configurable subdirectory (default `keolapses`) so it never collides with the regular timelapse video.
- Local-website subdirectory is created automatically; for remote (sftp/scp/ftp) destinations the subdirectory must already exist on the server.

### Other
- Runs on the `nightday` event; `periodic` is used only for testing features.
- Supports the WebUI [Test Module] button (with a separate "Upload test video" toggle).
- Publishes overlay variables: AS_KEOLAPSE_VIDEO, AS_KEOLAPSE_DATE, AS_KEOLAPSE_FRAMES, AS_KEOLAPSE_DURATION.
- No extra dependencies (OpenCV, NumPy, ffmpeg ship with core Allsky).

### Changelog
**v0.9.1**
- Fixed upload overwriting the regular timelapse video; keolapse now uploads into its own subdirectory with its dated filename.
- Added "Upload Subdirectory" setting (default `keolapses`).
- Corrected remote-server setting name (`useremoteserver`).
- Clearer error when a remote subdirectory is missing; local subdirectory created automatically.

**v0.9.0**
- Refactored to the Allsky v2025 module architecture.
- Core timelapse settings read via getSetting().
- Replaced custom upload script with standard upload.sh.
- Publishes AS_KEOLAPSE_* overlay variables; supports [Test Module].

Original module by Jim Cauthen; v2025 refactor by Andy Felong (AndyOfLinux). Tested on a live v2025.xx.xx installation (Raspberry Pi).