### PR TITLE
spaceweather: select the newest active rtsw/ record instead of data[-1]

### DIFF
--- a/allsky_spaceweather/README.md
+++ b/allsky_spaceweather/README.md
@@ -81,9 +81,9 @@ The module uses color coding to indicate parameter status:
 ## Data Sources
 
 This module uses the following NOAA SWPC APIs:
-- Solar Wind: https://services.swpc.noaa.gov/products/solar-wind/plasma-6-hour.json
+- Solar Wind: https://services.swpc.noaa.gov/json/rtsw/rtsw_wind_1m.json
 - Kp Index: https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json
-- Magnetic Field: https://services.swpc.noaa.gov/products/solar-wind/mag-6-hour.json
+- Magnetic Field: https://services.swpc.noaa.gov/json/rtsw/rtsw_mag_1m.json
 
 ## Requirements
 
@@ -109,6 +109,11 @@ Feel free to submit issues, fork the repository, and create pull requests for an
 ## License
 
 [MIT License](LICENSE)
+
+## Contributing Notes
+
+AI assistance was used while preparing this contribution. The generated code and
+documentation were reviewed and tested before submission.
 
 ## Acknowledgments
 

--- a/allsky_spaceweather/allsky_spaceweather.py
+++ b/allsky_spaceweather/allsky_spaceweather.py
@@ -16,6 +16,11 @@ import ephem
 import pytz
 import datetime
 
+# A selected rtsw/ record older than this means the feed has stalled, or that the
+# file ordering has changed again. Either way the values are not current and the
+# module says so rather than rendering them silently.
+RTSW_MAX_AGE_SECONDS = 1800
+
 class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 
 	meta_data = {
@@ -23,7 +28,7 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 		"description": "Retrieve space weather data from NOAA SWPC",
 		"docs": "docs/allsky_modules/extra/space_weather.html",    
 		"module": "allsky_spaceweather",
-		"version": "v1.0.2",
+		"version": "v1.0.4",
 		"centersettings": "false",
 		"testable": "true", 
 		"extradatafilename": "allsky_spaceweather.json",
@@ -132,7 +137,14 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 				"authorurl": "https://github.com/NightRide/",
 				"changes": "Updated to call new NOAA API endpoints published in 2026."
 				}
-			]     
+			],
+			"v1.0.4": [
+				{
+				"author": "Adrian Wells (Agent assisted)",
+				"authorurl": "https://github.com/adrianwells/",
+				"changes": "Select the newest active record from the rtsw/ endpoints rather than indexing by position, and write the extra data file even when the Bz fetch fails"
+				}
+			]
 		}
 	}
     
@@ -197,10 +209,66 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 					return None
 			return data
 
-	def _process_solar_wind_data(self, data):
-			"""Process solar wind data and return formatted values with colors"""
-			# --- Get the last record, handling both list and dict formats ---
-			last = data[-1]
+	def _record_age_seconds(self, record):
+			"""
+			Age of a record's time_tag in seconds, or None if it cannot be parsed.
+
+			The rtsw/ time_tag is naive UTC and sometimes carries fractional
+			seconds ("2026-08-31T11:08:06" or "...:06.123"), so only the first
+			19 characters are parsed.
+			"""
+			try:
+					tag = datetime.datetime.strptime(record["time_tag"][:19], "%Y-%m-%dT%H:%M:%S")
+			except (KeyError, TypeError, ValueError):
+					return None
+			now = datetime.datetime.now(tz=pytz.UTC).replace(tzinfo=None)
+			return (now - tag).total_seconds()
+
+	def _select_rtsw_record(self, data, label=""):
+			"""
+			Select the newest operational record from a NOAA RTSW product.
+
+			The json/rtsw/ files that replaced the retired products/solar-wind/
+			feeds differ from them in two ways that positional indexing cannot
+			survive:
+
+			  * they are ordered NEWEST FIRST over a rolling 24 hour window, so
+				data[-1] is the OLDEST record in the file, about 24 hours stale,
+				and
+			  * records from three spacecraft (SOLAR1, IMAP and ACE) interleave
+				in one file, each carrying a boolean "active", so no fixed
+				position identifies the operational one. data[0] is frequently
+				an inactive IMAP or ACE record.
+
+			So select explicitly: filter on active, then take the highest
+			time_tag.
+
+			Args:
+					data:  Parsed rtsw/ payload, or None if the fetch failed.
+					label: Human-readable label for log messages.
+			Returns:
+					The newest active record (dict), or None if there is none.
+			"""
+			if data is None:
+					return None
+
+			active = [record for record in data
+					if isinstance(record, dict) and record.get("active") and record.get("time_tag")]
+			if not active:
+					allsky_shared.log(0, f"ERROR: {label} API returned no active spacecraft records")
+					return None
+
+			newest = max(active, key=lambda record: record["time_tag"])
+			age = self._record_age_seconds(newest)
+			if age is None or age > RTSW_MAX_AGE_SECONDS:
+					allsky_shared.log(1, f"WARNING: {label} newest active record is not current "
+							f"({newest.get('time_tag')} from {newest.get('source')})")
+			return newest
+
+	def _process_solar_wind_data(self, record):
+			"""Process one solar wind record and return formatted values with colors"""
+			# --- The record is already selected; _get_record_value reads its fields ---
+			last = record
 			density = self._safe_float_conversion(self._get_record_value(last, 1, "proton_density"))
 			speed = self._safe_float_conversion(self._get_record_value(last, 2, "proton_speed"))
 			temp = self._safe_float_conversion(self._get_record_value(last, 3, "proton_temperature"))
@@ -295,9 +363,10 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 				# Fetch and process solar wind data
 				# ---------------------------------------------------------------
 				wind_data = self._fetch_json(urls["wind"], "Solar Wind")
-				if wind_data is not None:
+				wind_record = self._select_rtsw_record(wind_data, "Solar Wind")
+				if wind_record is not None:
 						try:
-								solar_wind = self._process_solar_wind_data(wind_data)
+								solar_wind = self._process_solar_wind_data(wind_record)
 								space_weather_data.update({
 										"SWX_SWIND_SPEED": {
 												"value": solar_wind["speed"]["value"],
@@ -345,9 +414,10 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 				# Fetch and process Bz data
 				# ---------------------------------------------------------------
 				bz_data = self._fetch_json(urls["bz"], "Bz")
-				if bz_data is not None:
+				bz_record = self._select_rtsw_record(bz_data, "Bz")
+				if bz_record is not None:
 						try:
-								last_bz = bz_data[-1]
+								last_bz = bz_record
 								# Handle both list and dict formats for Bz value
 								bz_value = float(self._get_record_value(last_bz, 3, "bz_gsm"))
 								bz_color = "#10e310"  # default green
@@ -364,11 +434,12 @@ class ALLSKYSPACEWEATHER(ALLSKYMODULEBASE):
 						except Exception as e:
 								allsky_shared.log(0, f"ERROR: Failed to process Bz data: {e}")
 				
-						# Save data to file
-						allsky_shared.saveExtraData(self.meta_data['extradatafilename'], space_weather_data, self.meta_data['module'], self.meta_data['extradata'], event=self.event)
-						result = f"Space weather data successfully written to {self.meta_data['extradatafilename']}"
-						self.log(1, f"INFO: {result}")
-						allsky_shared.setLastRun(module)
+				# Save whatever was collected. One endpoint failing must not discard
+				# the fields that succeeded, or the whole file freezes.
+				allsky_shared.saveExtraData(self.meta_data['extradatafilename'], space_weather_data, self.meta_data['module'], self.meta_data['extradata'], event=self.event)
+				result = f"Space weather data successfully written to {self.meta_data['extradatafilename']}"
+				self.log(1, f"INFO: {result}")
+				allsky_shared.setLastRun(module)
 
 			else:
 					result = f"Last run {diff} seconds ago. Running every {period} seconds"

--- a/allsky_spaceweather/manifest.json
+++ b/allsky_spaceweather/manifest.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
   "module": "allsky_spaceweather",
-  "generated_utc": "2026-08-31T20:49:29Z",
+  "generated_utc": "2026-09-04T11:45:52Z",
   "hash_algorithm": "sha256",
   "files": {
     "README.md": {
-      "sha256": "b2b275cb219fd7e9c0948c3bcb996deaa6917e23812d0d01af2ec22db26d4ccc",
-      "size": 3124,
+      "sha256": "bdd2310f1b2367f98d925786553f3a5ec9b3577a3c5478ce2c45ee32f9e952ee",
+      "size": 3267,
       "mode": "644"
     },
     "allsky_spaceweather.py": {
-      "sha256": "d6c92fa1dce1d647b7919678f681adce35b34e69891084f87f28b28f68f4c48d",
-      "size": 12382,
+      "sha256": "883361f4d8722b5e2321f7007790f46015b5f076e7c88b7c92491d26fb2075ac",
+      "size": 15273,
       "mode": "755"
     },
     "requirements.txt": {


### PR DESCRIPTION
Fixes #350. Follows on from #346, which repointed the solar wind and Bz sources at
`json/rtsw/` after NOAA retired the DSCOVR products. Thanks for the quick turnaround on
that one; it fixed a hard outage.

### The problem

The `rtsw/` files are ordered newest-first, and records from three spacecraft (SOLAR1, IMAP
and ACE) interleave in the same file, each carrying an `active` flag. So `data[-1]` lands on
the oldest record in the file, often from a spacecraft that is not the operational one.

In a sample from 31 Aug, `data[-1]` was an inactive ACE record from 24 hours earlier
reporting `bz_gsm` 3.67, while the newest `active` record (SOLAR1) read -0.09. Solar wind
speed showed the same pattern, 451.71 against 443.4. Nothing is logged as an error, which
is what makes it easy to miss. The Kp endpoint is still chronological and is untouched.

### Changes

**`allsky_spaceweather.py`**

- `_select_rtsw_record()`: filter on `active`, take the highest `time_tag`. Used for the two
  `rtsw/` sources only.
- A `WARNING` when the selected record is more than 30 minutes old, so a stalled feed or a
  future ordering change surfaces in the log rather than as quietly old numbers.
- `_process_solar_wind_data()` now takes the selected record rather than the whole payload.
- The save, log and `setLastRun` calls dedented out of `if bz_data is not None:`, matching
  `master`. One endpoint failing no longer discards the fields that succeeded. If all three
  fail, the file is now written with only the sun angle, where previously nothing was
  written and the old values persisted.
- Version to `v1.0.4`. #346 added a `v1.0.3` changelog entry but left `"version"` at
  `"v1.0.2"`, so this bumps past both rather than editing that entry.

**`README.md`**

- The two "Data Sources" URLs still pointed at the `products/solar-wind/` endpoints retired
  on 30 Jun 2026. Corrected to the `rtsw/` URLs the code now fetches. The Kp line never
  moved and is unchanged.
- AI-assistance declaration, as the contributing guide asks. The changelog author is marked
  `(Agent assisted)`, matching the existing v1.0.3 entry.

**`manifest.json`**

- Regenerated with `tools/create-module-manifest.sh allsky_spaceweather`, since it carries a
  sha256 and size for both files above.

### Base branch

Based on `v2025.xx.xx` rather than `master`, because the code being fixed only exists there:
`master` still carries the pre-refactor `v1.0.1` module without the #346 cutover, and
`create-module-manifest.sh` is not on `master` either. Happy to retarget if `master` is
preferred.

### Testing

18 tests over payloads captured 31 Aug, run offline in a container with `--network none`,
plus an opt-in live run and a run against the real `allsky_shared` and `allsky_base` from
this branch. Four of the 18 run the *unpatched* module against the same fixtures and assert
the current behaviour, so the claims above break loudly rather than quietly if upstream
changes. Suite and fixtures: not published anywhere yet, but happy to attach them or push them to a gist.

Not covered: the flow-runner invocation, and the camera, MySQL, systemd and hardware paths.
None of those are on this module's path, but a check on a real `v2025.xx.xx` install before
merge would still be worth having, since the install used here is a released build whose
copy of the module predates #346.

### Not included

Each `rtsw/` file is fetched whole on every run, 2.8 MB and 1.7 MB uncompressed. Because
they are newest-first, `Range: bytes=0-8191` with `Accept-Encoding: identity` returns enough
to select an active record, for roughly 340x less traffic. That has been running on a Pi
since 30 Aug with selected values matching a full fetch exactly, but it is an optimisation
rather than a correctness fix, so it is kept out of this PR. Happy to open it separately.
